### PR TITLE
fix: set last working version of colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -677,9 +677,9 @@
       "dev": true
     },
     "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "combined-stream": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "performant"
   ],
   "dependencies": {
-    "colors": "^1.1.2",
+    "colors": "1.4.0",
     "lodash": "^4.17.15",
     "safe-json-stringify": "^1.2.0",
     "serr": "^1.0.1"


### PR DESCRIPTION
Demoting colors library version due to DDoS issue provoked by its owner.

https://www.theverge.com/2022/1/9/22874949/developer-corrupts-open-source-libraries-projects-affected

https://github.com/Marak/colors.js/commit/074a0f8ed0c31c35d13d28632bd8a049ff136fb6